### PR TITLE
fix language is always English in Edge Chromium

### DIFF
--- a/js/viewer.js
+++ b/js/viewer.js
@@ -17,7 +17,9 @@ redirectIfNotDisplayedInFrame();
 		return window.parent.t('files_mindmap', msg);
 	};
 
-	var lang = window.lang || 'en';
+	var lang = window.lang || 
+				 (document.getElementById("viewer") && document.getElementById("viewer").getAttribute("lang")) ||
+				 'en';
 
 	var MindMap = {
 		_changed: false,

--- a/templates/viewer.php
+++ b/templates/viewer.php
@@ -141,7 +141,7 @@
         </li>
     </ul>
 </div>
-<kityminder-editor id="viewer" on-init="initEditor(editor, minder)"></kityminder-editor>
+<kityminder-editor id="viewer" lang="<?=$lang?>" on-init="initEditor(editor, minder)"></kityminder-editor>
 </body>
 
 <script nonce="<?=$nonce?>" src="<?php p($urlGenerator->linkTo('files_mindmap', 'vendor/jquery/dist/jquery.js')) ?>?v=<?php p($version) ?>"></script>


### PR DESCRIPTION
I found that I cannot get the "lang" field from the window object in Edge Chromium browser, so I also set the "lang" as a attribute to editor element.
My browser version is Edge Chromium 79.0.309.47 beta (64 bit).