### PR TITLE
Need to handle the old OCA\Files_Sharing::loadAdditionalScripts event…

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -39,6 +39,11 @@ class Application extends App implements IBootstrap {
 			LoadAdditionalScriptsEvent::class,
 			LoadAdditionalScripts::class
 		);
+
+		$container = $this->getContainer();
+		/** @var  IEventDispatcher $eventDispatcher */
+		$eventDispatcher = $container->get(IEventDispatcher::class);
+		$eventDispatcher->addListener('OCA\Files_Sharing::loadAdditionalScripts', array('OCA\Files_MindMap\Listener\LoadAdditionalScripts','additionalScripts'));
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/Listener/LoadAdditionalScripts.php
+++ b/lib/Listener/LoadAdditionalScripts.php
@@ -15,7 +15,10 @@ class LoadAdditionalScripts implements IEventListener {
 		if (!($event instanceof LoadAdditionalScriptsEvent)) {
 			return;
 		}
+		self::additionalScripts();
+	}
 
+	public static function additionalScripts() {
 		Util::addStyle(Application::APPNAME, 'style');
 		Util::addScript(Application::APPNAME, 'jszip');
 		Util::addScript(Application::APPNAME, 'mindmap');


### PR DESCRIPTION
The OCA\Files_Sharing::loadAdditionalScripts is still generated from BeforeTemplateRenderedEvent.

We have the choices to Listen to BeforeTemplateRenderedEvent also. But i think the legacy event is still maintained and is more significant (in order to load scripts) than "BeforeTemplate..."