### PR TITLE
Remove pseudo sandbox

### DIFF
--- a/js/mindmap.js
+++ b/js/mindmap.js
@@ -80,8 +80,7 @@ var FilesMindMap = {
 		var shown = true;
 		var viewer = OC.generateUrl('/apps/files_mindmap/');
 		$iframe = $('<iframe id="mmframe" style="width:100%;height:100%;display:block;position:absolute;top:0;' +
-            'z-index:1041;" src="'+viewer+'" sandbox="allow-scripts allow-same-origin allow-downloads allow-popups allow-modals ' +
-            'allow-top-navigation allow-presentation" allowfullscreen="true"/>');
+            'z-index:1041;" src="'+viewer+'" allowfullscreen="true"/>');
 
 		if (!$('#mimetype').val()) {
 			FileList.setViewerMode(true);


### PR DESCRIPTION
The iframe containing the mindmap is sandboxed, but this sandbox does not provide any additional security because it uses allow-scripts and allow-same-origin at the same time so that any script within the iframe could just remove the sandbox attribute.
 
Source: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#allow-top-navigation-to-custom-protocols
> When the embedded document has the same origin as the embedding page, it is strongly discouraged to use both allow-scripts and allow-same-origin, as that lets the embedded document remove the sandbox attribute — making it no more secure than not using the sandbox attribute at all.

This pull request removes the sandbox attribute, solving the following issue https://github.com/ACTom/files_mindmap/issues/165 without decreasing security as there is no security benefit of the sandbox in the first place.