### PR TITLE
fix: Update CSP API calls for Nextcloud 31+ compatibility

### DIFF
--- a/lib/Controller/DisplayController.php
+++ b/lib/Controller/DisplayController.php
@@ -57,7 +57,7 @@ class DisplayController extends Controller {
         $policy->addAllowedFontDomain('data:');
         $policy->addAllowedImageDomain('*');
         $policy->addAllowedConnectDomain('data:');
-        $policy->allowEvalScript(true);
+        $policy->addAllowedScriptDomain('\'unsafe-eval\'');
         $response->setContentSecurityPolicy($policy);
 
         return $response;

--- a/templates/viewer.php
+++ b/templates/viewer.php
@@ -5,11 +5,7 @@
     $urlGenerator = \OC::$server->get(IURLGenerator::class);
     $version = \OC::$server[IAppManager::class]->getAppVersion('files_mindmap');
     $lang = $_['lang'];
-    if (method_exists(\OC::$server, 'getContentSecurityPolicyNonceManager')) {
-        $nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
-    } else {
-        $nonce = '';
-    }
+    $nonce = $_['cspNonce'] ?? '';
 ?>
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
Replace removed allowEvalScript() with addAllowedScriptDomain() and use $_['cspNonce'] instead of removed getContentSecurityPolicyNonceManager().

AI-Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>