### PR TITLE
Ensure viewer HTML is revalidated 

### DIFF
--- a/lib/Controller/DisplayController.php
+++ b/lib/Controller/DisplayController.php
@@ -47,6 +47,7 @@ class DisplayController extends Controller {
             'lang' => $this->l10nFactory->findLanguage()
 		];
 		$response = new TemplateResponse($this->appName, 'viewer', $params, 'blank');
+		$response->addHeader('Cache-Control', 'no-cache');
 		
         $policy = new ContentSecurityPolicy();
         $policy->addAllowedFrameDomain('\'self\'');


### PR DESCRIPTION
on app/any update to prevent stale asset cache

This is a quick fix, the viewer html is very small, so "no cache" can be lived with given changing the vue implementation would be a bigger effort to get the script loading fixed upon update.