### PR TITLE
Security: Content Security Policy allows unsafe-eval

### DIFF
--- a/lib/Controller/DisplayController.php
+++ b/lib/Controller/DisplayController.php
@@ -65,7 +65,6 @@ class DisplayController extends Controller {
         $policy->addAllowedFontDomain('data:');
         $policy->addAllowedImageDomain('*');
         $policy->addAllowedConnectDomain('data:');
-        $policy->addAllowedScriptDomain('\'unsafe-eval\'');
         $response->setContentSecurityPolicy($policy);
 
         return $response;


### PR DESCRIPTION
## Summary

Security: Content Security Policy allows unsafe-eval

## Problem

**Severity**: `Critical` | **File**: `lib/Controller/DisplayController.php:L54`

In lib/Controller/DisplayController.php, the ContentSecurityPolicy allows 'unsafe-eval' script domain. This severely weakens CSP protection and allows inline JavaScript execution, making the application vulnerable to XSS attacks.

## Solution

Remove the line '$policy->addAllowedScriptDomain('\'unsafe-eval\'');' or replace with specific allowed script sources. If inline scripts are needed, use nonces instead.

## Changes

- `lib/Controller/DisplayController.php` (modified)